### PR TITLE
CachedAsyncImageの初期化コストを下げる

### DIFF
--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -68,8 +68,6 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     @State private var phase: AsyncImagePhase
     
     private let urlRequest: URLRequest?
-    
-    private let urlSession: URLSession
 
     private let urlCache: URLCache
     
@@ -296,10 +294,7 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     ///   - content: A closure that takes the load phase as an input, and
     ///     returns the view to display for the specified phase.
     public init(urlRequest: URLRequest?, urlCache: URLCache = .shared, scale: CGFloat = 1, transaction: Transaction = Transaction(), @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
-        let configuration = URLSessionConfiguration.default
-        configuration.urlCache = urlCache
         self.urlRequest = urlRequest
-        self.urlSession =  URLSession(configuration: configuration)
         self.urlCache = urlCache
         self.scale = scale
         self.transaction = transaction
@@ -318,6 +313,9 @@ public struct CachedAsyncImage<Content>: View where Content: View {
                     return
                 }
 
+                let configuration = URLSessionConfiguration.default
+                configuration.urlCache = self.urlCache
+                let urlSession = URLSession(configuration: configuration)
                 let (image, metrics) = try await remoteImage(from: urlRequest, session: urlSession)
                 if metrics.transactionMetrics.last?.resourceFetchType == .localCache {
                     // WARNING: This does not behave well when the url is changed with another

--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -307,7 +307,7 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     private func load() async {
         do {
             if let urlRequest = urlRequest {
-                if let image = try? cachedImage(from: urlRequest, cache: self.urlCache) {
+                if let image = try? cachedImage(from: urlRequest, cache: urlCache) {
                     // WARNING: This does not behave well when the url is changed with another
                     phase = .success(image)
                     return


### PR DESCRIPTION
ListやLazy系のViewを用いた時、Viewのinitのコストが高くスクロールがガタつく不具合への対応。

- イニシャライザで行っている重い処理を`.task(_:)`内で行うように変更した。
  - `cachedImage(from:cache:)`
  - `URLSession(configuration:)`
- 画像取得の処理をMainActorから分離しメインスレッドの負荷を下げた。